### PR TITLE
remove superfluous enum class definition on the ParseEnum annotation

### DIFF
--- a/super-csv-declarative/src/main/java/com/github/dmn1k/supercsv/io/declarative/annotation/ParseEnum.java
+++ b/super-csv-declarative/src/main/java/com/github/dmn1k/supercsv/io/declarative/annotation/ParseEnum.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2007 Kasper B. Graversen
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,15 +15,14 @@
  */
 package com.github.dmn1k.supercsv.io.declarative.annotation;
 
+import com.github.dmn1k.supercsv.io.declarative.CellProcessorAnnotationDescriptor;
+import com.github.dmn1k.supercsv.io.declarative.ProcessorOrder;
+import com.github.dmn1k.supercsv.io.declarative.StandardCsvContexts;
+import com.github.dmn1k.supercsv.io.declarative.provider.ParseEnumCellProcessorProvider;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
-import com.github.dmn1k.supercsv.io.declarative.ProcessorOrder;
-import com.github.dmn1k.supercsv.io.declarative.provider.ParseEnumCellProcessorProvider;
-import com.github.dmn1k.supercsv.io.declarative.CellProcessorAnnotationDescriptor;
-import com.github.dmn1k.supercsv.io.declarative.StandardCsvContexts;
 
 /**
  * Annotation for the {@link org.supercsv.cellprocessor.ParseEnum}-cell processor
@@ -35,8 +34,6 @@ import com.github.dmn1k.supercsv.io.declarative.StandardCsvContexts;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.FIELD})
 public @interface ParseEnum {
-
-    Class<? extends Enum<?>> enumClass();
 
     boolean ignoreCase() default false;
 

--- a/super-csv-declarative/src/main/java/com/github/dmn1k/supercsv/io/declarative/provider/ParseEnumCellProcessorProvider.java
+++ b/super-csv-declarative/src/main/java/com/github/dmn1k/supercsv/io/declarative/provider/ParseEnumCellProcessorProvider.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2007 Kasper B. Graversen
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,10 +15,10 @@
  */
 package com.github.dmn1k.supercsv.io.declarative.provider;
 
+import com.github.dmn1k.supercsv.io.declarative.annotation.ParseEnum;
 import com.github.dmn1k.supercsv.model.CellProcessorFactory;
 import com.github.dmn1k.supercsv.model.DeclarativeCellProcessorProvider;
 import com.github.dmn1k.supercsv.model.ProcessingMetadata;
-import com.github.dmn1k.supercsv.io.declarative.annotation.ParseEnum;
 import org.supercsv.cellprocessor.ift.CellProcessor;
 
 /**
@@ -43,7 +43,8 @@ public class ParseEnumCellProcessorProvider implements DeclarativeCellProcessorP
 
             @Override
             public CellProcessor create(CellProcessor next) {
-                return new org.supercsv.cellprocessor.ParseEnum(metadata.getAnnotation().enumClass(), metadata.getAnnotation().ignoreCase(), next);
+                final Class<? extends Enum> enumClass = (Class<? extends Enum>) metadata.getField().getType();
+                return new org.supercsv.cellprocessor.ParseEnum(enumClass, metadata.getAnnotation().ignoreCase(), next);
             }
         };
     }


### PR DESCRIPTION
As the title says: Remove the requirement to explicitly define the enum class in the annotation again as this is double work which can lead to errors. It's possible to get the field type via reflection.

Optionally one could check the field type explicitly in the CellProcessorProvider before the casting happens:

    if (metadata.getField().isEnumConstant()) {
        ...
    } else {
        throw new ...
    }